### PR TITLE
[MAPA-226] feat: adds volunteer_unsubscriptions table

### DIFF
--- a/migrations/20240326214330_adds_volunteer_unsubscriptions_table/migration.sql
+++ b/migrations/20240326214330_adds_volunteer_unsubscriptions_table/migration.sql
@@ -1,0 +1,19 @@
+-- AlterTable
+ALTER TABLE "public"."volunteer_segments" ALTER COLUMN "created_at" SET DATA TYPE TIMESTAMP(6),
+ALTER COLUMN "updated_at" DROP DEFAULT,
+ALTER COLUMN "updated_at" SET DATA TYPE TIMESTAMP(6);
+
+-- CreateTable
+CREATE TABLE "public"."volunteer_unsubscriptions" (
+    "volunteer_unsubscription_id" BIGSERIAL NOT NULL,
+    "volunteer_id" INTEGER NOT NULL,
+    "unsubscription_reason" VARCHAR NOT NULL,
+    "unsubscription_description" TEXT NOT NULL,
+    "created_at" TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(6) NOT NULL,
+
+    CONSTRAINT "volunteer_unsubscriptions_pkey" PRIMARY KEY ("volunteer_unsubscription_id")
+);
+
+-- AddForeignKey
+ALTER TABLE "public"."volunteer_unsubscriptions" ADD CONSTRAINT "volunteer_unsubscriptions_volunteer_id_fkey" FOREIGN KEY ("volunteer_id") REFERENCES "public"."volunteers"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/schema.prisma
+++ b/schema.prisma
@@ -209,6 +209,7 @@ model Volunteers {
   volunteer_status_history VolunteerStatusHistory[]
   volunteers_formdata      volunteers_formdata?     @relation(fields: [form_data_id], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "volunteers_volunteer_form_data_id_ec6c5a18_fk_volunteer")
   volunteer_segments       VolunteerSegments[]
+  volunteer_unsubscriptions       VolunteerUnsubscriptions[]
 
   @@index([form_data_id], map: "volunteers_volunteer_form_data_id_ec6c5a18")
   @@map("volunteers")
@@ -373,6 +374,20 @@ model VolunteerSegments {
   @@map("volunteer_segments")
   @@schema("public")
 
+}
+
+model VolunteerUnsubscriptions {
+  volunteer_unsubscription_id BigInt @id @default(autoincrement())
+  volunteer_id Int
+  unsubscription_reason String @db.VarChar()
+  unsubscription_description String @db.Text()
+  created_at DateTime @default(now()) @db.Timestamp(6)
+  updated_at DateTime @updatedAt @map("updated_at") @db.Timestamp(6)
+
+  volunteers   Volunteers @relation(fields: [volunteer_id], references: [id])
+
+  @@map("volunteer_unsubscriptions")
+  @@schema("public")
 }
 
 model FeatureFlag {


### PR DESCRIPTION
Esse PR adiciona a tabela `volunteer_unsubscriptions`, que irá guardar os dados sobre o descadastro das voluntárias realizado pelo formulário no Tally.