### PR TITLE
[MAPA-234] feat: adds columns to multipliers table

### DIFF
--- a/migrations/20240401203114_adds_columns_to_multipliers_table/migration.sql
+++ b/migrations/20240401203114_adds_columns_to_multipliers_table/migration.sql
@@ -1,0 +1,9 @@
+-- CreateEnum
+CREATE TYPE "mobilization"."multiplier_household_type" AS ENUM ('urban', 'rural', 'not_found');
+
+-- AlterTable
+ALTER TABLE "mobilization"."multipliers" ADD COLUMN     "city" VARCHAR(100) NOT NULL DEFAULT 'not_found',
+ADD COLUMN     "disability_type" TEXT[],
+ADD COLUMN     "has_children" BOOLEAN,
+ADD COLUMN     "household_type" "mobilization"."multiplier_household_type" NOT NULL DEFAULT 'not_found',
+ADD COLUMN     "how_many_children" INTEGER;

--- a/migrations/20240401203254_adds_default_to_disability_type/migration.sql
+++ b/migrations/20240401203254_adds_default_to_disability_type/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "mobilization"."multipliers" ALTER COLUMN "disability_type" SET DEFAULT ARRAY[]::TEXT[];

--- a/migrations/20240401204651_adds_multiplier_journey_events_table/migration.sql
+++ b/migrations/20240401204651_adds_multiplier_journey_events_table/migration.sql
@@ -1,0 +1,12 @@
+-- CreateEnum
+CREATE TYPE "mobilization"."multiplier_journey_event" AS ENUM ('registration', 'general_onboarding');
+
+-- CreateTable
+CREATE TABLE "mobilization"."multiplier_journey_events" (
+    "multiplier_journey_event_id" SERIAL NOT NULL,
+    "multiplier_id" INTEGER NOT NULL,
+    "event" "mobilization"."multiplier_journey_event" NOT NULL,
+    "created_at" TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "multiplier_journey_events_pkey" PRIMARY KEY ("multiplier_journey_event_id")
+);

--- a/migrations/20240402124510_links_multipliers_to_journey_events/migration.sql
+++ b/migrations/20240402124510_links_multipliers_to_journey_events/migration.sql
@@ -1,0 +1,2 @@
+-- AddForeignKey
+ALTER TABLE "mobilization"."multiplier_journey_events" ADD CONSTRAINT "multiplier_journey_events_multiplier_id_fkey" FOREIGN KEY ("multiplier_id") REFERENCES "mobilization"."multipliers"("multiplier_id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/schema.prisma
+++ b/schema.prisma
@@ -493,6 +493,7 @@ model Mutipliers {
   updatedAt                           DateTime                             @updatedAt @map("updated_at") @db.Timestamp(6)
   multiplierPii                       MutiplierPii?
   multiplierRegistrationOpenQuestions MultiplierRegistrationOpenQuestions?
+  multiplierJourneyEvents             MultiplierJourneyEvents[]
 
   @@map("multipliers")
   @@schema("mobilization")
@@ -521,17 +522,19 @@ model MultiplierRegistrationOpenQuestions {
   universityCourse                          String     @map("university_course") @db.VarChar(200)
   howSheHeardAboutUs                        String     @map("how_she_heard_about_us") @db.Text
   reasonsForParticipating                   String     @map("reasons_for_participating") @db.Text
-  multupliers                               Mutipliers @relation(fields: [multiplierId], references: [multiplierId])
+  multipliers                               Mutipliers @relation(fields: [multiplierId], references: [multiplierId])
 
   @@map("multiplier_registration_open_questions")
   @@schema("mobilization")
 }
 
 model MultiplierJourneyEvents {
-  multiplier_journey_event_id       Int         @id @default(autoincrement()) @map("multiplier_journey_event_id")
-  multiplier_id                     Int 
-  event                             MultiplierJourneyEvent
-  created_at                        DateTime    @default(now()) @map("created_at") @db.Timestamp(6)
+  multiplierJourneyEventId          Int                     @id @default(autoincrement()) @map("multiplier_journey_event_id")
+  multiplierId                      Int                     @map("multiplier_id")
+  event                             MultiplierJourneyEvent  
+  createdAt                         DateTime                @default(now()) @map("created_at") @db.Timestamp(6)
+
+  multipliers                       Mutipliers             @relation(fields: [multiplierId], references: [multiplierId])
 
   @@map("multiplier_journey_events")
   @@schema("mobilization")

--- a/schema.prisma
+++ b/schema.prisma
@@ -527,6 +527,17 @@ model MultiplierRegistrationOpenQuestions {
   @@schema("mobilization")
 }
 
+model MultiplierJourneyEvents {
+  multiplier_journey_event_id       Int         @id @default(autoincrement()) @map("multiplier_journey_event_id")
+  multiplier_id                     Int 
+  event                             MultiplierJourneyEvent
+  created_at                        DateTime    @default(now()) @map("created_at") @db.Timestamp(6)
+
+  @@map("multiplier_journey_events")
+  @@schema("mobilization")
+
+}
+
 enum SupportType {
   psychological
   legal
@@ -677,6 +688,14 @@ enum MultiplierHouseholdType {
   not_found
 
   @@map("multiplier_household_type")
+  @@schema("mobilization")
+}
+
+enum MultiplierJourneyEvent {
+  registration
+  general_onboarding
+
+  @@map("multiplier_journey_event")
   @@schema("mobilization")
 }
 

--- a/schema.prisma
+++ b/schema.prisma
@@ -474,10 +474,15 @@ model Mutipliers {
   age                                 Int
   region                              Region
   state                               String                               @db.VarChar(9)
+  city                                String                               @db.VarChar(100) @default("not_found")
+  householdType                       MultiplierHouseholdType              @default(not_found) @map("household_type")
+  hasChildren                         Boolean?                             @map("has_children")
+  howManyChildren                     Int?                                 @map("how_many_children")
   race                                Race
   sexuality                           Sexuality
   religion                            Religion
   hasDisability                       Boolean                              @map("has_disability")
+  disabilityType                      String[]                             @map("disability_type") @default([])
   hasInternetAccess                   Boolean                              @map("has_internet_access")
   isAvailable                         Boolean                              @map("is_available")
   shiftAvailability                   String[]                             @map("shift_availability")
@@ -663,6 +668,15 @@ enum MultiplierUniversityType {
   not_found
 
   @@map("multiplier_university_type")
+  @@schema("mobilization")
+}
+
+enum MultiplierHouseholdType {
+  urban
+  rural
+  not_found
+
+  @@map("multiplier_household_type")
   @@schema("mobilization")
 }
 


### PR DESCRIPTION
Esse PR faz duas coisas:
1. Adiciona colunas na tabela `multipliers`. As respostas para essas colunas foram obtidas através do segundo formulário de multiplicadoras.
2. Adiciona a tabela `multiplier_journey_events` para guardar os eventos da jornada da multiplicadora