### PR TITLE
[MAPA-433] fix: small fixes on msr tables

### DIFF
--- a/migrations/20240709200154_makes_msr_first_name_and_last_name_nullable/migration.sql
+++ b/migrations/20240709200154_makes_msr_first_name_and_last_name_nullable/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "pii_sec"."msr_pii" ALTER COLUMN "first_name" DROP NOT NULL,
+ALTER COLUMN "last_name" DROP NOT NULL;

--- a/migrations/20240709200930_creates_unregistered_msr_status/migration.sql
+++ b/migrations/20240709200930_creates_unregistered_msr_status/migration.sql
@@ -1,0 +1,14 @@
+/*
+  Warnings:
+
+  - The values [unsubscribed] on the enum `msr_status` will be removed. If these variants are still used in the database, this will fail.
+
+*/
+-- AlterEnum
+BEGIN;
+CREATE TYPE "msr"."msr_status_new" AS ENUM ('registered', 'unregistered');
+ALTER TABLE "msr"."msrs" ALTER COLUMN "status" TYPE "msr"."msr_status_new" USING ("status"::text::"msr"."msr_status_new");
+ALTER TYPE "msr"."msr_status" RENAME TO "msr_status_old";
+ALTER TYPE "msr"."msr_status_new" RENAME TO "msr_status";
+DROP TYPE "msr"."msr_status_old";
+COMMIT;

--- a/migrations/20240711174737_removes_last_name_from_msr_pii/migration.sql
+++ b/migrations/20240711174737_removes_last_name_from_msr_pii/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `last_name` on the `msr_pii` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "pii_sec"."msr_pii" DROP COLUMN "last_name";

--- a/schema.prisma
+++ b/schema.prisma
@@ -558,7 +558,7 @@ enum SupportType {
 
 enum MSRStatus {
   registered
-  unsubscribed
+  unregistered
 
   @@map("msr_status")
   @@schema("msr")

--- a/schema.prisma
+++ b/schema.prisma
@@ -246,7 +246,6 @@ model MSRs {
 model MSRPiiSec {
   msrId       BigInt   @id @default(autoincrement()) @map("msr_id")
   firstName   String?   @map("first_name") @db.VarChar(200)
-  lastName    String?   @map("last_name") @db.VarChar(200)
   email       String   @unique @db.VarChar(254)
   phone       String   @db.VarChar(100)
   dateOfBirth DateTime? @map("date_of_birth") @db.Date

--- a/schema.prisma
+++ b/schema.prisma
@@ -245,8 +245,8 @@ model MSRs {
 
 model MSRPiiSec {
   msrId       BigInt   @id @default(autoincrement()) @map("msr_id")
-  firstName   String   @map("first_name") @db.VarChar(200)
-  lastName    String   @map("last_name") @db.VarChar(200)
+  firstName   String?   @map("first_name") @db.VarChar(200)
+  lastName    String?   @map("last_name") @db.VarChar(200)
   email       String   @unique @db.VarChar(254)
   phone       String   @db.VarChar(100)
   dateOfBirth DateTime? @map("date_of_birth") @db.Date

--- a/schema.prisma
+++ b/schema.prisma
@@ -7,7 +7,7 @@ generator client {
 datasource db {
   provider = "postgresql"
   url      = env("DATABASE_URL")
-  schemas  = ["match", "public", "mobilization", "public_services", "msr", "pii_sec", "pii_mask"]
+  schemas  = ["match", "public", "mobilization", "public_services", "msr", "pii_sec"]
 }
 
 model auth_group {


### PR DESCRIPTION
Esse PR faz alguns fix nas tabelas de MSRs:
- Permite que `first_name` seja nulo. Tomamos essa decisão para evitar esses dados sejam usados em comunicações e o resultado seja algo tipo "olá, not_found".
- Adiciona o status `unregistered` e deleta o status `unsubscribed` para as MSRs por questões de padronização.
- Delete o schema `pii_mask` pois não vamos utilizá-lo.
- Deleta a coluna `last_name` da tabela `msr_pii` pois não iremos utilizá-la.