### PR TITLE
[MAPA-438] feat: adds match_confirmation tables

### DIFF
--- a/migrations/20240718184444_adds_match_confirmation_tables/migration.sql
+++ b/migrations/20240718184444_adds_match_confirmation_tables/migration.sql
@@ -1,0 +1,32 @@
+-- CreateEnum
+CREATE TYPE "match"."match_confirmation_status" AS ENUM ('waiting', 'confirmed', 'denied', 'failed');
+
+-- CreateTable
+CREATE TABLE "match"."match_confirmations" (
+    "match_confirmation_id" SERIAL NOT NULL,
+    "support_request_id" INTEGER NOT NULL,
+    "msr_id" BIGINT NOT NULL,
+    "volunteer_id" INTEGER,
+    "status" "match"."match_confirmation_status" NOT NULL,
+    "match_id" INTEGER,
+    "created_at" TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(6) NOT NULL,
+
+    CONSTRAINT "match_confirmations_pkey" PRIMARY KEY ("match_confirmation_id")
+);
+
+-- CreateTable
+CREATE TABLE "match"."match_confirmation_status_history" (
+    "match_confirmation_status_history_id" SERIAL NOT NULL,
+    "match_confirmation_id" INTEGER NOT NULL,
+    "status" "match"."match_confirmation_status" NOT NULL,
+    "created_at" TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "match_confirmation_status_history_pkey" PRIMARY KEY ("match_confirmation_status_history_id")
+);
+
+-- AddForeignKey
+ALTER TABLE "match"."match_confirmations" ADD CONSTRAINT "match_confirmations_support_request_id_fkey" FOREIGN KEY ("support_request_id") REFERENCES "match"."support_requests"("support_request_id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "match"."match_confirmation_status_history" ADD CONSTRAINT "match_confirmation_status_history_match_confirmation_id_fkey" FOREIGN KEY ("match_confirmation_id") REFERENCES "match"."match_confirmations"("match_confirmation_id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/migrations/20240718191549_makes_volunteer_id_not_null_on_match_confirmations/migration.sql
+++ b/migrations/20240718191549_makes_volunteer_id_not_null_on_match_confirmations/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Made the column `volunteer_id` on table `match_confirmations` required. This step will fail if there are existing NULL values in that column.
+
+*/
+-- AlterTable
+ALTER TABLE "match"."match_confirmations" ALTER COLUMN "volunteer_id" SET NOT NULL;

--- a/schema.prisma
+++ b/schema.prisma
@@ -237,20 +237,20 @@ model MSRs {
   createdAt            DateTime  @default(now()) @map("created_at") @db.Timestamp(6)
   updatedAt            DateTime  @updatedAt @map("updated_at") @db.Timestamp(6)
 
-  MSRPii     MSRPiiSec?
+  MSRPii MSRPiiSec?
 
   @@map("msrs")
   @@schema("msr")
 }
 
 model MSRPiiSec {
-  msrId       BigInt   @id @default(autoincrement()) @map("msr_id")
+  msrId       BigInt    @id @default(autoincrement()) @map("msr_id")
   firstName   String?   @map("first_name") @db.VarChar(200)
-  email       String   @unique @db.VarChar(254)
-  phone       String   @db.VarChar(100)
+  email       String    @unique @db.VarChar(254)
+  phone       String    @db.VarChar(100)
   dateOfBirth DateTime? @map("date_of_birth") @db.Date
-  createdAt   DateTime @default(now()) @map("created_at") @db.Timestamp(6)
-  updatedAt   DateTime @updatedAt @map("updated_at") @db.Timestamp(6)
+  createdAt   DateTime  @default(now()) @map("created_at") @db.Timestamp(6)
+  updatedAt   DateTime  @updatedAt @map("updated_at") @db.Timestamp(6)
 
   MSRs MSRs @relation(fields: [msrId], references: [msrId])
 
@@ -276,6 +276,7 @@ model SupportRequests {
   createdAt                   DateTime                      @default(now()) @map("created_at") @db.Timestamp(6)
   updatedAt                   DateTime                      @updatedAt @map("updated_at") @db.Timestamp(6)
   Matches                     Matches[]
+  MatchConfirmations          MatchConfirmations[]
   SupportRequestStatusHistory SupportRequestStatusHistory[]
 
   @@map("support_requests")
@@ -312,6 +313,34 @@ model Matches {
   volunteer                Volunteers?          @relation(fields: [volunteerId], references: [id])
 
   @@map("matches")
+  @@schema("match")
+}
+
+model MatchConfirmations {
+  matchConfirmationId Int                     @id @default(autoincrement()) @map("match_confirmation_id")
+  supportRequestId    Int                     @map("support_request_id")
+  msrId               BigInt                  @map("msr_id")
+  volunteerId         Int?                    @map("volunteer_id")
+  status              MatchConfirmationStatus
+  matchId             Int?                    @map("match_id")
+  createdAt           DateTime                @default(now()) @map("created_at") @db.Timestamp(6)
+  updatedAt           DateTime                @updatedAt @map("updated_at") @db.Timestamp(6)
+
+  SupportRequest                 SupportRequests                  @relation(fields: [supportRequestId], references: [supportRequestId])
+  MatchConfirmationStatusHistory MatchConfirmationStatusHistory[]
+
+  @@map("match_confirmations")
+  @@schema("match")
+}
+
+model MatchConfirmationStatusHistory {
+  matchConfirmationStatusHistoryId Int                     @id @default(autoincrement()) @map("match_confirmation_status_history_id")
+  matchConfirmationId              Int                     @map("match_confirmation_id")
+  status                           MatchConfirmationStatus
+  createdAt                        DateTime                @default(now()) @map("created_at") @db.Timestamp(6)
+  MatchConfirmation                MatchConfirmations      @relation(fields: [matchConfirmationId], references: [matchConfirmationId])
+
+  @@map("match_confirmation_status_history")
   @@schema("match")
 }
 
@@ -613,6 +642,16 @@ enum MatchStatus {
   started_contact
 
   @@map("match_status")
+  @@schema("match")
+}
+
+enum MatchConfirmationStatus {
+  waiting
+  confirmed
+  denied
+  failed
+
+  @@map("match_confirmation_status")
   @@schema("match")
 }
 

--- a/schema.prisma
+++ b/schema.prisma
@@ -320,7 +320,7 @@ model MatchConfirmations {
   matchConfirmationId Int                     @id @default(autoincrement()) @map("match_confirmation_id")
   supportRequestId    Int                     @map("support_request_id")
   msrId               BigInt                  @map("msr_id")
-  volunteerId         Int?                    @map("volunteer_id")
+  volunteerId         Int                     @map("volunteer_id")
   status              MatchConfirmationStatus
   matchId             Int?                    @map("match_id")
   createdAt           DateTime                @default(now()) @map("created_at") @db.Timestamp(6)


### PR DESCRIPTION
Esse PR adiciona as tabelas relativas ao serviço de confirmação da disponibilidade da voluntária

<img width="1428" alt="image" src="https://github.com/user-attachments/assets/45b25ccf-8498-43d5-ae50-eaf0e3450c42">
