### PR TITLE
[MAPA-528] feat: adds msr_status_history

### DIFF
--- a/migrations/20240725185033_creates_msr_status_history/migration.sql
+++ b/migrations/20240725185033_creates_msr_status_history/migration.sql
@@ -1,0 +1,12 @@
+-- CreateTable
+CREATE TABLE "msr"."msr_status_history" (
+    "msr_status_history_id" SERIAL NOT NULL,
+    "msr_id" BIGINT NOT NULL,
+    "status" "msr"."msr_status" NOT NULL,
+    "created_at" TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "msr_status_history_pkey" PRIMARY KEY ("msr_status_history_id")
+);
+
+-- AddForeignKey
+ALTER TABLE "msr"."msr_status_history" ADD CONSTRAINT "msr_status_history_msr_id_fkey" FOREIGN KEY ("msr_id") REFERENCES "msr"."msrs"("msr_id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/schema.prisma
+++ b/schema.prisma
@@ -237,7 +237,8 @@ model MSRs {
   createdAt            DateTime  @default(now()) @map("created_at") @db.Timestamp(6)
   updatedAt            DateTime  @updatedAt @map("updated_at") @db.Timestamp(6)
 
-  MSRPii MSRPiiSec?
+  MSRPii           MSRPiiSec?
+  MSRStatusHistory MSRStatusHistory[]
 
   @@map("msrs")
   @@schema("msr")
@@ -256,6 +257,18 @@ model MSRPiiSec {
 
   @@map("msr_pii")
   @@schema("pii_sec")
+}
+
+model MSRStatusHistory {
+  msrStatusHistoryId Int       @id @default(autoincrement()) @map("msr_status_history_id")
+  msrId              BigInt    @map("msr_id")
+  status             MSRStatus
+  createdAt          DateTime  @default(now()) @map("created_at") @db.Timestamp(6)
+  
+  MSRs               MSRs      @relation(fields: [msrId], references: [msrId])
+
+  @@map("msr_status_history")
+  @@schema("msr")
 }
 
 model SupportRequests {


### PR DESCRIPTION
Esse PR criar a tabela `msr_status_history` para armazenar o histórico de status da MSR.