### PR TITLE
fix: adds expired to match_confirmation status enum

### DIFF
--- a/migrations/20240903181254_adds_expired_to_match_confirmation_status_enum/migration.sql
+++ b/migrations/20240903181254_adds_expired_to_match_confirmation_status_enum/migration.sql
@@ -1,0 +1,15 @@
+/*
+  Warnings:
+
+  - The values [failed] on the enum `match_confirmation_status` will be removed. If these variants are still used in the database, this will fail.
+
+*/
+-- AlterEnum
+BEGIN;
+CREATE TYPE "match"."match_confirmation_status_new" AS ENUM ('waiting', 'confirmed', 'denied', 'expired');
+ALTER TABLE "match"."match_confirmations" ALTER COLUMN "status" TYPE "match"."match_confirmation_status_new" USING ("status"::text::"match"."match_confirmation_status_new");
+ALTER TABLE "match"."match_confirmation_status_history" ALTER COLUMN "status" TYPE "match"."match_confirmation_status_new" USING ("status"::text::"match"."match_confirmation_status_new");
+ALTER TYPE "match"."match_confirmation_status" RENAME TO "match_confirmation_status_old";
+ALTER TYPE "match"."match_confirmation_status_new" RENAME TO "match_confirmation_status";
+DROP TYPE "match"."match_confirmation_status_old";
+COMMIT;

--- a/schema.prisma
+++ b/schema.prisma
@@ -665,7 +665,7 @@ enum MatchConfirmationStatus {
   waiting
   confirmed
   denied
-  failed
+  expired
 
   @@map("match_confirmation_status")
   @@schema("match")


### PR DESCRIPTION
## Pull Request Template

### Descrição
Esse PR adiciona o status `expired` ao status do `match_confirmation`

### Checklist
- [x] Eu testei as alterações localmente.
- [x] Eu revisei o código em busca de possíveis problemas.
- [x] Eu atualizei a [documentação do banco de dados](https://miro.com/app/board/uXjVMzPi3ZA=/?moveToWidget=3458764593396659368&cot=14), se necessário.

