### PR TITLE
feat: allows null values for volunteer birth_date

### DIFF
--- a/postgres/migrations/20250211143411_allows_null_values_for_volunteer_birth_date/migration.sql
+++ b/postgres/migrations/20250211143411_allows_null_values_for_volunteer_birth_date/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "public"."volunteers" ALTER COLUMN "birth_date" DROP NOT NULL;

--- a/postgres/schema.prisma
+++ b/postgres/schema.prisma
@@ -179,7 +179,7 @@ model Volunteers {
   latitude                   Decimal?                   @db.Decimal(10, 4)
   longitude                  Decimal?                   @db.Decimal(10, 4)
   registrationNumber         String                     @map("register_number") @db.VarChar(400)
-  birth_date                 DateTime                   @db.Timestamptz(6)
+  birth_date                 DateTime?                  @db.Timestamptz(6)
   color                      String                     @db.VarChar(100)
   gender                     String                     @db.VarChar(100)
   modality                   String                     @db.VarChar(100)


### PR DESCRIPTION
## Pull Request Template

### Descrição
Esse PR permite valores nulos na coluna `birth_date` da tabela `volunteers`.

### Checklist
- [x] Eu testei as alterações localmente.
- [x] Eu revisei o código em busca de possíveis problemas.
- [x] Eu atualizei a [documentação do banco de dados](https://miro.com/app/board/uXjVMzPi3ZA=/?moveToWidget=3458764593396659368&cot=14), se necessário.


